### PR TITLE
Fix initiaize in MPU6886.ino

### DIFF
--- a/examples/Basics/MPU6886/MPU6886.ino
+++ b/examples/Basics/MPU6886/MPU6886.ino
@@ -10,14 +10,14 @@
 * Date: 2022/12/19
 *******************************************************************************
 */
-#include "M5AtomS3.h"
+#include <M5AtomS3.h>
 
 /* After AtomS3 is started or reset the program in the setUp ()
 function will be run, and this part will only be run once.
 在 AtomS3 启动或者复位后，即会开始执行setup()函数中的程序，该部分只会执行一次。
 */
 void setup() {
-    M5.begin(true, true, false,
+    M5.begin(true, true, true,
              false);  // Init AtomS3(Initialize LCD, serial port).
                       // 初始化 AtomS3(初始化LCD、串口)
     M5.IMU.begin();   // Init IMU sensor.  初始化姿态传感器


### PR DESCRIPTION
I2C module function is not enabled in MPU6886.ino, so it does not work with ATOMS3.
Please fix it.

![Screenshot from 2022-12-28 22-01-20](https://user-images.githubusercontent.com/67567093/209816860-91bf6da7-0169-4910-9e17-a4ccc6118f3b.png)
