### PR TITLE
Swap LCD to use second SPI bus, correct color order, fix offset, fix rotation

### DIFF
--- a/src/utility/In_eSPI_Drivers/ST7789_Rotation.h
+++ b/src/utility/In_eSPI_Drivers/ST7789_Rotation.h
@@ -18,8 +18,8 @@ switch (rotation) {
             colstart = 35;
             rowstart = 0;
         } else {
-            colstart = 0;
-            rowstart = 0;
+            colstart = 2;
+            rowstart = 1;
         }
 #endif
         writedata(TFT_MAD_COLOR_ORDER);
@@ -43,8 +43,8 @@ switch (rotation) {
             colstart = 0;
             rowstart = 35;
         } else {
-            colstart = 0;
-            rowstart = 0;
+            colstart = 1;
+            rowstart = 2;
         }
 #endif
         writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_COLOR_ORDER);
@@ -68,8 +68,8 @@ switch (rotation) {
             colstart = 35;
             rowstart = 0;
         } else {
-            colstart = 0;
-            rowstart = 80;
+            colstart = 2;
+            rowstart = 1;
         }
 #endif
         writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
@@ -92,8 +92,8 @@ switch (rotation) {
             colstart = 0;
             rowstart = 35;
         } else {
-            colstart = 80;
-            rowstart = 0;
+            colstart = 1;
+            rowstart = 2;
         }
 #endif
         writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_COLOR_ORDER);

--- a/src/utility/In_eSPI_Setup.h
+++ b/src/utility/In_eSPI_Setup.h
@@ -1,3 +1,6 @@
+#define TFT_RGB_ORDER 0 // Use the correct RGB order for the display
+                        // Must be set before ST7789_Defines.h is included
+
 #include "In_eSPI_Drivers/ST7789_Defines.h"
 
 #define ST7789_DRIVER  // Full configuration option, define additional

--- a/src/utility/In_eSPI_Setup.h
+++ b/src/utility/In_eSPI_Setup.h
@@ -3,6 +3,9 @@
 #define ST7789_DRIVER  // Full configuration option, define additional
                        // parameters below for this display
 
+#define USE_HSPI_PORT  // Use the second SPI port for the display, keeping the default 
+                       // SPI port free for use on the Atom expansion port
+
 #define TFT_DRIVER 0x7789
 #define TFT_WIDTH  129
 #define TFT_HEIGHT 129

--- a/src/utility/In_eSPI_Setup.h
+++ b/src/utility/In_eSPI_Setup.h
@@ -1,5 +1,9 @@
 #define TFT_RGB_ORDER 0 // Use the correct RGB order for the display
-                        // Must be set before ST7789_Defines.h is included
+
+#define CGRAM_OFFSET    // Display has an offset that needs to be corrected
+                        // Offset corrections in In_eSPI_Drivers\ST7789_Rotation.h
+
+                        // Above values must be set before ST7789_Defines.h is included
 
 #include "In_eSPI_Drivers/ST7789_Defines.h"
 
@@ -10,8 +14,8 @@
                        // SPI port free for use on the Atom expansion port
 
 #define TFT_DRIVER 0x7789
-#define TFT_WIDTH  129
-#define TFT_HEIGHT 129
+#define TFT_WIDTH  128
+#define TFT_HEIGHT 128
 
 #define TFT_MISO -1
 #define TFT_MOSI 21


### PR DESCRIPTION
Use the second hardware SPI port for the built in display, keeping the default port free for use on the expansion port.  This allows the AtomS3 module to be used with AtomPOE base and the default Arduino ethernet library.

Swap color order from RGB to BGR to match the LCD used.

Correct a +2,+1 offset between the display space and the LCD itself, which led to clipping and inaccessible pixels.

Fix the "inverted" rotation positions.