### PR TITLE
Allow changing MPU-6886 measurement range

### DIFF
--- a/src/utility/MPU6886.h
+++ b/src/utility/MPU6886.h
@@ -4,9 +4,14 @@
 #include <Wire.h>
 
 #define MPU6886_DEFAULT_ADDRESS 0x68
+#define MPU6886_GYRO_CONFIG     0x1B
+#define MPU6886_ACCEL_CONFIG    0x1C
 
 class MPU6886 {
    public:
+    enum Ascale { AFS_2G = 0, AFS_4G, AFS_8G, AFS_16G };
+    enum Gscale { GFS_250DPS = 0, GFS_500DPS, GFS_1000DPS, GFS_2000DPS };
+
     MPU6886(uint8_t deviceAddress = MPU6886_DEFAULT_ADDRESS,
             TwoWire& i2cPort      = Wire1);
 
@@ -18,6 +23,9 @@ class MPU6886 {
     void getGyro(float* gx, float* gy, float* gz);
     void getTemp(float* t);
 
+    void setGyroFsr(Gscale scale);
+    void setAccelFsr(Ascale scale);
+
    private:
     uint8_t readByte(uint8_t address);
     void writeByte(uint8_t address, uint8_t data);
@@ -26,6 +34,11 @@ class MPU6886 {
 
     TwoWire* _i2cPort;
     int _deviceAddress;
+
+    Gscale _gyroScale;
+    float _gRes;
+    Ascale _accelScale;
+    float _aRes;
 };
 
 #endif


### PR DESCRIPTION
The functions to change the full-scale ranges of MPU-6886 gyro/accelerometer are currently missing in the M5AtomS3 library.
The feature is available in "M5Stack" library. https://github.com/m5stack/M5Stack/blob/master/src/utility/MPU6886.cpp
Therefore having the same functionality in S3 would help migrate several applications from such devices.
